### PR TITLE
fix:prelineの修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,4 +2,3 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import 'preline';
-import 'preline/dist/preline.css';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js',
     'node_modules/preline/dist/*.js',
+    './node_modules/preline/dist/*.js',
   ],
   plugins: [
     require("daisyui"),


### PR DESCRIPTION
# 概要
prelineの導入時に不備があったため、修正。

## 実装内容
- app/javascript/application.html.erbの以下削除
```
import 'preline/dist/preline.css';
```

## 未実装内容
なし

## 補足
なし