### PR TITLE
fix/デプロイエラーの対処

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,6 +22,9 @@ RUN apt-get update -qq && apt-get install -y \
   yarn \
   vim
 
+# Tailwind CSS と esbuild のインストール
+RUN yarn global add esbuild tailwindcss
+
 # アプリケーションディレクトリの作成
 RUN mkdir /myapp
 WORKDIR /myapp


### PR DESCRIPTION
# 概要
デプロイすると「We're sorry, but something went wrong.」のエラーが出ているため対処。

## 実装内容
- Dockerfile.devにtailwindcss,esbuildのinstallを追記
```
# Tailwind CSS と esbuild のインストール
RUN yarn global add esbuild tailwindcss
```
 
## 未実装内容
なし

## 補足
TailwindCSS,esbuildのインストールを記述していた際にエラーが出ていなかったため、元に戻します。